### PR TITLE
[Fix] randint params

### DIFF
--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -34,7 +34,7 @@ class DefaultRecs:
         if not cls._recs:
             return True
         # add random jitter to prevent multiple unneeded db hits at the same time
-        jitter_sec = randint(30)
+        jitter_sec = randint(1, 30)
         stale_threshold = datetime.now() - timedelta(
             minutes=cls.STALE_AFTER_MIN, seconds=jitter_sec
         )


### PR DESCRIPTION
## description 
fixes a small bug being thrown on dev: `ERROR:root:internal_error: randint() missing 1 required positional argument: 'b'` 

not sure why this didn't fail locally. perhaps we need to start pinning the minor python version in the dockerfile. 

## testing 
works on dev after an `npx cdk deploy` 