### PR TITLE
Add model articles endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ class Application(tornado.web.Application):
             (r"^/recs/?$", recommendation.RecHandler),
             (r"^/models/?$", model.ModelHandler),
             (r"^/models/(\d+)/set_current/?", model.ModelHandler),
+            (r"^/models/(\d+)/articles/?", model.ModelArticleHandler),
         ]
 
         super(Application, self).__init__(app_handlers, **APP_SETTINGS)

--- a/db/helpers.py
+++ b/db/helpers.py
@@ -7,6 +7,10 @@ from peewee import Expression, InterfaceError
 from db.mappings.base import BaseMapping, tzaware_now
 from db.mappings.article import Article
 from lib.db import db
+from lib.config import config
+
+
+MAX_PAGE_SIZE = config.get("MAX_PAGE_SIZE")
 
 
 def create_resource(mapping_class: BaseMapping, **params: dict) -> int:
@@ -31,8 +35,10 @@ def update_resources(
 def get_articles_by_external_ids(site: str, external_ids: List[str]) -> List[dict]:
     res = (
         Article.select()
-        .where((Article.site == site) & Article.external_id.in_(list(external_ids)))
+        .where((Article.site == site))
+        .where(Article.external_id.in_(list(external_ids)))
         .order_by(Article.published_at.desc())
+        .limit(MAX_PAGE_SIZE)
     )
     if res:
         return [r.to_dict() for r in res]

--- a/tests/handlers/test_model_handler.py
+++ b/tests/handlers/test_model_handler.py
@@ -3,10 +3,79 @@ import json
 import tornado.testing
 
 from tests.factories.model import ModelFactory
+from tests.factories.article import ArticleFactory
+from tests.factories.recommendation import RecFactory
 from tests.base import BaseTest
 from db.mappings.model import Type, Status, Site, Model
 from db.helpers import get_resource
 from lib.config import config
+
+
+class TestModelArticleHandler(BaseTest):
+    _endpoint = "/models"
+
+    @tornado.testing.gen_test
+    async def test_get__missing_resource__throws_error(self):
+        response = await self.http_client.fetch(
+            self.get_url(f"{self._endpoint}/1/articles"),
+            method="GET",
+            raise_error=False,
+        )
+
+        assert response.code == 404
+
+    @tornado.testing.gen_test
+    async def test_get(self):
+        misc_model = ModelFactory.create(
+            status=Status.CURRENT.value, site=Site.TEXAS_TRIBUNE.value
+        )
+        target_model = ModelFactory.create(
+            status=Status.STALE.value, site=Site.TEXAS_TRIBUNE.value
+        )
+
+        misc_article = ArticleFactory.create(site=Site.TEXAS_TRIBUNE.value)
+        target_article_1 = ArticleFactory.create(site=Site.TEXAS_TRIBUNE.value)
+        target_article_2 = ArticleFactory.create(site=Site.TEXAS_TRIBUNE.value)
+
+        recommended_article = ArticleFactory.create(site=Site.TEXAS_TRIBUNE.value)
+
+        RecFactory.create(
+            model_id=misc_model["id"],
+            source_entity_id=misc_article["external_id"],
+            recommended_article_id=recommended_article["id"],
+        )
+        RecFactory.create(
+            model_id=misc_model["id"],
+            source_entity_id=target_article_1["external_id"],
+            recommended_article_id=recommended_article["id"],
+        )
+
+        RecFactory.create(
+            model_id=target_model["id"],
+            source_entity_id=target_article_1["external_id"],
+            recommended_article_id=recommended_article["id"],
+        )
+        RecFactory.create(
+            model_id=target_model["id"],
+            source_entity_id=target_article_2["external_id"],
+            recommended_article_id=recommended_article["id"],
+        )
+
+        response = await self.http_client.fetch(
+            self.get_url(f"{self._endpoint}/{target_model['id']}/articles"),
+            method="GET",
+            raise_error=False,
+        )
+
+        assert response.code == 200
+
+        results = json.loads(response.body)
+        articles = results["results"]
+        assert len(articles) == 2
+
+        article_ids = {a["id"] for a in articles}
+        assert target_article_1["id"] in article_ids
+        assert target_article_2["id"] in article_ids
 
 
 class TestModelHandler(BaseTest):


### PR DESCRIPTION
## description 
add endpoint that the team can use to get a list of all articles a given model has recommendations for 

this will allow us to qa and demo model prototypes more easily 

## testing 
- [x] works locally 
- [x] works in dev 

## screenshots
<img width="1092" alt="Screen Shot 2021-12-14 at 1 31 40 PM" src="https://user-images.githubusercontent.com/7977127/146059151-3390be6c-7aaa-47ef-80a7-6fbf65d28332.png">

