### PR TITLE
[Remove] old type check for entity id

### DIFF
--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -110,12 +110,6 @@ class RecHandler(APIHandler):
     def validate_filters(self, **filters) -> Dict[str, str]:
         error_msgs = {}
 
-        if "source_entity_id" in filters:
-            try:
-                int(filters["source_entity_id"])
-            except ValueError:
-                return f"Invalid input for 'source_entity_id' (int): {filters['source_entity_id']}"
-
         if "exclude" in filters:
             for exclude in filters["exclude"].split(","):
                 try:

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -383,22 +383,6 @@ class TestRecHandler(BaseTest):
         assert results["results"][0]["model"]["id"] == article_mdl["id"]
 
     @tornado.testing.gen_test
-    async def test_get__invalid_source_entity_id(self):
-        invalid_id = "not_an_int"
-        response = await self.http_client.fetch(
-            self.get_url(f"{self._endpoint}?source_entity_id={invalid_id}"),
-            method="GET",
-            raise_error=False,
-        )
-
-        assert response.code == 400
-
-        results = json.loads(response.body)
-
-        expected_msg = f"Invalid input for 'source_entity_id' (int): {invalid_id}"
-        assert results["message"] == expected_msg
-
-    @tornado.testing.gen_test
     async def test_get__invalid_exclude(self):
         invalid_id = "not_an_int"
         response = await self.http_client.fetch(


### PR DESCRIPTION
## description
now that article external id's are text rather than ints, remove type check that's preventing us from surfacing inquirer recs 