### PR TITLE
[update] pin netmask

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -30,6 +30,7 @@
     "@aws-cdk/aws-elasticloadbalancingv2": "1.86.0",
     "@aws-cdk/aws-iam": "1.86.0",
     "@aws-cdk/core": "1.86.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "netmask": ">=2.0.1"
   }
 }


### PR DESCRIPTION
## description
fix critical dependabot alert https://github.com/LocalAtBrown/article-rec-api/security/dependabot/7 

## cdk output
```
~/lnl/article-rec-api/cdk [fix-critical-dependency●] npx cdk diff ArticleRecAPI
Stack ArticleRecAPI
Resources
[~] AWS::ECS::TaskDefinition ArticleRecAPIService/TaskDef ArticleRecAPIServiceTaskDef9B10A3A7 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -16,7 +16,7 @@
        [ ]       {
        [ ]         "Ref": "AWS::URLSuffix"
        [ ]       },
        [-]       "/aws-cdk/assets:7e610afaed48af34eee5f31efdfc62511fcf68b12a8c0be6d5e4aeb874a70161"
        [+]       "/aws-cdk/assets:26b1cd24ce070f0a8c530043a68da76e6be6c3eed7ccf97cd401226c26ba33ca"
        [ ]     ]
        [ ]   ]
        [ ] },

**************************************************
*** Newer version of CDK is available [2.12.0] ***
*** Upgrade recommended                        ***
**************************************************
```

## testing 
- [x] deployed to dev 
- [x] npm test passed