### PR TITLE
[add] total_rec_requests metric

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+from typing import Dict
 
 import tornado.autoreload
 import tornado.web

--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -25,6 +25,8 @@ STALE_AFTER_MIN = 15
 DEFAULT_REC_COUNTER: Dict[str, int] = {}
 # counter of db hits by site
 DB_HIT_COUNTER: Dict[str, int] = {}
+# counter of all handled requests by site
+TOTAL_HANDLED: Dict[str, int] = {}
 
 
 def incr_metric_total(counter: Dict[str, int], site: str) -> None:
@@ -205,4 +207,5 @@ class RecHandler(APIHandler):
             "results": self.fetch_results(**filters)
             or DefaultRecs.get_recs(filters["site"], filters.get("source_entity_id")),
         }
+        incr_metric_total(TOTAL_HANDLED, filters["site"])
         self.api_response(res)


### PR DESCRIPTION
## description
i've been noticing some off behavior using aggregate_latency.sample_count to capture the total number of recommendation requests. (i wonder if the sample_count is not appropriately summed across instances?) this pr writes an additional metric to make our dashboards more straightforward to reason about 