### PR TITLE
[update] replace cache with smarter implementation that supports

### DIFF
--- a/handlers/base.py
+++ b/handlers/base.py
@@ -33,11 +33,6 @@ def default_serializer(obj):
     raise TypeError(f"couldn't serialize obj: {obj}")
 
 
-def get_ttl_hash(seconds: int = 3600) -> int:
-    """Return the same value withing `seconds` time period"""
-    return round(time.time() / seconds)
-
-
 class LatencyBuffer:
     def __init__(self):
         self._buffer = []

--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -19,8 +19,8 @@ from lib.metrics import write_metric, Unit
 
 MAX_PAGE_SIZE = config.get("MAX_PAGE_SIZE")
 DEFAULT_SITE = config.get("DEFAULT_SITE")
-# ttl for caching
 STALE_AFTER_MIN = 15
+TTL_CACHE = TTLCache(maxsize=2048, ttl=STALE_AFTER_MIN * 60)
 # counter of default recs served for site
 DEFAULT_REC_COUNTER: Dict[str, int] = {}
 # counter of db hits by site
@@ -164,9 +164,7 @@ class RecHandler(APIHandler):
 
     # each result takes roughly 50,000 bytes
     # so 2048 cached results ~= 100 MBs
-    @cached(
-        cache=TTLCache(maxsize=2048, ttl=STALE_AFTER_MIN * 60), key=instance_unaware_key
-    )
+    @cached(cache=TTL_CACHE, key=instance_unaware_key)
     def fetch_cached_results(
         self,
         source_entity_id: Optional[str] = None,

--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -20,6 +20,7 @@ from lib.metrics import write_metric, Unit
 MAX_PAGE_SIZE = config.get("MAX_PAGE_SIZE")
 DEFAULT_SITE = config.get("DEFAULT_SITE")
 STALE_AFTER_MIN = 15
+# each result takes roughly 50,000 bytes; 2048 cached results ~= 100 MBs
 TTL_CACHE = TTLCache(maxsize=2048, ttl=STALE_AFTER_MIN * 60)
 # counter of default recs served for site
 DEFAULT_REC_COUNTER: Dict[str, int] = {}
@@ -162,8 +163,6 @@ class RecHandler(APIHandler):
 
         return error_msgs
 
-    # each result takes roughly 50,000 bytes
-    # so 2048 cached results ~= 100 MBs
     @cached(cache=TTL_CACHE, key=instance_unaware_key)
     def fetch_cached_results(
         self,

--- a/requirements.in
+++ b/requirements.in
@@ -6,4 +6,4 @@ peewee
 psycopg2-binary
 tornado
 pytest
-methodtools
+cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ botocore==1.19.5
     # via
     #   boto3
     #   s3transfer
+cachetools==5.0.0
+    # via -r requirements.in
 click==7.1.2
     # via flask
 flask==1.1.2
@@ -30,8 +32,6 @@ jmespath==0.10.0
     #   botocore
 markupsafe==1.1.1
     # via jinja2
-methodtools==0.4.5
-    # via -r requirements.in
 packaging==20.9
     # via pytest
 peewee==3.14.0
@@ -51,9 +51,7 @@ python-dateutil==2.8.1
 s3transfer==0.3.3
     # via boto3
 six==1.15.0
-    # via
-    #   python-dateutil
-    #   wirerope
+    # via python-dateutil
 toml==0.10.2
     # via pytest
 tornado==6.1
@@ -64,5 +62,3 @@ uwsgi==2.0.19.1
     # via -r requirements.in
 werkzeug==1.0.1
     # via flask
-wirerope==0.4.5
-    # via methodtools

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -415,8 +415,8 @@ class TestRecHandler(BaseTest):
         expected_msg = f"Invalid input for 'model_id' (int): {invalid_id}"
         assert results["message"] == expected_msg
 
-    @tornado.testing.gen_test
     @patch("handlers.recommendation.incr_metric_total")
+    @tornado.testing.gen_test
     async def test_get__duplicate_requests_cached(self, mock_incr_metric_total):
         article = ArticleFactory.create()
         model = ModelFactory.create()

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -18,6 +18,10 @@ MAX_PAGE_SIZE = config.get("MAX_PAGE_SIZE")
 class TestRecHandler(BaseTest):
     _endpoint = "/recs"
 
+    def setUp(self) -> None:
+        TTL_CACHE.clear()
+        super().setUp()
+
     @tornado.testing.gen_test
     async def test_get__size__limits_items(self):
         article = ArticleFactory.create()
@@ -442,7 +446,6 @@ class TestRecHandler(BaseTest):
         )
 
         assert len(TTL_CACHE.keys()) == 1
-        TTL_CACHE.clear()
 
     @tornado.testing.gen_test
     async def test_get__different_requests(self):
@@ -470,4 +473,3 @@ class TestRecHandler(BaseTest):
         )
 
         assert len(TTL_CACHE.keys()) == 2
-        TTL_CACHE.clear()


### PR DESCRIPTION
## description 
previously, our caching would not cover the case where multiple instances of the rec handler class made the same query 

this pr replaces the cache with a smarter implementation that supports
- per-item ttl
- custom hash key