### PR TITLE
apply size param to default recs

### DIFF
--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -53,7 +53,7 @@ class DefaultRecs:
 
     @classmethod
     @retry_rollback
-    def get_recs(cls, site: str, external_id: str) -> List[Dict[str, Any]]:
+    def get_recs(cls, site: str, external_id: str, size: int) -> List[Dict[str, Any]]:
         incr_metric_total(DEFAULT_REC_COUNTER, site)
         logging.info(
             f"Returning default recs for site:{site}, external_id:{external_id}"
@@ -77,7 +77,8 @@ class DefaultRecs:
             cls._recs[site] = [x.to_dict() for x in query]
             cls._last_updated[site] = datetime.now()
 
-        return cls._recs[site]
+        recs = cls._recs[site]
+        return recs[:size] if len(recs) > size else recs
 
     @classmethod
     def should_refresh(cls, site):
@@ -205,9 +206,12 @@ class RecHandler(APIHandler):
         validation_errors = self.validate_filters(**filters)
         if validation_errors:
             raise tornado.web.HTTPError(status_code=400, log_message=validation_errors)
+
         res = {
             "results": self.fetch_results(**filters)
-            or DefaultRecs.get_recs(filters["site"], filters.get("source_entity_id")),
+            or DefaultRecs.get_recs(
+                filters["site"], filters.get("source_entity_id"), int(filters["size"])
+            ),
         }
         incr_metric_total(TOTAL_HANDLED, filters["site"])
         self.api_response(res)

--- a/handlers/recommendation.py
+++ b/handlers/recommendation.py
@@ -78,7 +78,7 @@ class DefaultRecs:
             cls._last_updated[site] = datetime.now()
 
         recs = cls._recs[site]
-        return recs[:size] if len(recs) > size else recs
+        return recs[:size]
 
     @classmethod
     def should_refresh(cls, site):

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -48,11 +48,18 @@ class TestRecHandler(BaseTest):
         model = ModelFactory.create(
             type=Type.POPULARITY.value, status=Status.CURRENT.value
         )
-        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
-        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
-        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
-
-        size = 2
+        recs = [
+            RecFactory.create(
+                model_id=model["id"], recommended_article_id=article["id"]
+            ),
+            RecFactory.create(
+                model_id=model["id"], recommended_article_id=article["id"]
+            ),
+            RecFactory.create(
+                model_id=model["id"], recommended_article_id=article["id"]
+            ),
+        ]
+        size = len(recs) - 1
         site = config.get("DEFAULT_SITE")
         request_type = Type.ARTICLE.value
         response = await self.http_client.fetch(
@@ -62,9 +69,7 @@ class TestRecHandler(BaseTest):
             method="GET",
             raise_error=False,
         )
-
         assert response.code == 200
-
         results = json.loads(response.body)
         assert len(results["results"]) == size
 
@@ -85,7 +90,6 @@ class TestRecHandler(BaseTest):
                 model_id=model["id"], recommended_article_id=article["id"]
             ),
         ]
-
         size = len(recs) + 1
         site = config.get("DEFAULT_SITE")
         request_type = Type.ARTICLE.value
@@ -96,9 +100,7 @@ class TestRecHandler(BaseTest):
             method="GET",
             raise_error=False,
         )
-
         assert response.code == 200
-
         results = json.loads(response.body)
         assert len(results["results"]) == len(recs)
 

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -43,6 +43,32 @@ class TestRecHandler(BaseTest):
         assert len(results["results"]) == size
 
     @tornado.testing.gen_test
+    async def test_get__size__limits_default_items(self):
+        article = ArticleFactory.create()
+        model = ModelFactory.create(
+            type=Type.POPULARITY.value, status=Status.CURRENT.value
+        )
+        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
+        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
+        RecFactory.create(model_id=model["id"], recommended_article_id=article["id"])
+
+        size = 2
+        site = config.get("DEFAULT_SITE")
+        request_type = Type.ARTICLE.value
+        response = await self.http_client.fetch(
+            self.get_url(
+                f"{self._endpoint}?site={site}&model_type={request_type}&size={size}"
+            ),
+            method="GET",
+            raise_error=False,
+        )
+
+        assert response.code == 200
+
+        results = json.loads(response.body)
+        assert len(results["results"]) == size
+
+    @tornado.testing.gen_test
     async def test_get__invalid_size__raises_error(self):
         article = ArticleFactory.create()
         model = ModelFactory.create()

--- a/tests/handlers/test_recommendation_handler.py
+++ b/tests/handlers/test_recommendation_handler.py
@@ -103,29 +103,6 @@ class TestRecHandler(BaseTest):
         assert len(results["results"]) == len(recs)
 
     @tornado.testing.gen_test
-    async def test_get__size__default_items__empty_res(self):
-        article = ArticleFactory.create()
-        model = ModelFactory.create(
-            type=Type.POPULARITY.value, status=Status.CURRENT.value
-        )
-
-        size = 2
-        site = config.get("DEFAULT_SITE")
-        request_type = Type.ARTICLE.value
-        response = await self.http_client.fetch(
-            self.get_url(
-                f"{self._endpoint}?site={site}&model_type={request_type}&size={size}"
-            ),
-            method="GET",
-            raise_error=False,
-        )
-
-        assert response.code == 200
-
-        results = json.loads(response.body)
-        assert len(results["results"]) == 0
-
-    @tornado.testing.gen_test
     async def test_get__invalid_size__raises_error(self):
         article = ArticleFactory.create()
         model = ModelFactory.create()


### PR DESCRIPTION
## description 
this pr fixes the following issue identified by @SimmonsRitchie:

when requesting an article for which we have article-to-article recs, the size param works as expected, but, when requesting an article for which we don’t have article-to-article recs and instead return the default popularity based recs, the size param is not applied

## testing
- [x] tested on dev 
