### PR TITLE
Health handler pings db

### DIFF
--- a/Karfile
+++ b/Karfile
@@ -10,10 +10,16 @@ DOCKER_OPTS=$(cat <<END_HEREDOC
 END_HEREDOC
 )
 
-#@cdk
-#+Run cdk.
-task-cdk() {
-    (cd cdk && npx cdk $@)
+#@deploy
+#+CDK deploy.
+task-deploy() {
+    echo "Deploying all dev stacks..."
+    cd cdk
+    for stack in $(npx cdk list | grep Dev)
+    do
+        npx cdk deploy $stack
+    done
+    cd ..
 }
 
 #@build

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ kar test
 For dev deployment, run:
 
 ```
-kar cdk deploy DevArticleRecAPI
+kar deploy
 ```
 
 Each pull request to main will trigger a new prod deployment when merged.

--- a/app.py
+++ b/app.py
@@ -65,15 +65,6 @@ async def empty_metric_buffers():
                 )
 
 
-async def restart_db_connection():
-    INTERVAL_MIN = 1
-    while True:
-        await asyncio.sleep(INTERVAL_MIN * 60)
-        if db_proxy.is_closed():
-            logging.info("Resetting db conn...")
-            db_proxy.connect()
-
-
 if __name__ == "__main__":
     if config.get("DEBUG") is True:
         tornado.autoreload.start()
@@ -90,5 +81,4 @@ if __name__ == "__main__":
     http_server.listen(port)
     io_loop = tornado.ioloop.IOLoop.current()
     io_loop.add_callback(empty_metric_buffers)
-    io_loop.add_callback(restart_db_connection)
     io_loop.start()

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -77,7 +77,7 @@ export class AppStack extends cdk.Stack {
       cluster,
       cpu: 256,
       memoryLimitMiB: 256,
-      desiredCount: props.stage === helpers.STAGE.PRODUCTION  ? 3 : 1,
+      desiredCount: 3,
       domainName,
       domainZone,
       certificate,

--- a/handlers/base.py
+++ b/handlers/base.py
@@ -125,18 +125,12 @@ class HealthHandler(BaseHandler):
     """Return 200 OK."""
 
     def get(self):
-        db_health = self.db_health()
-        if not db_health:
+        is_closed = db_proxy.is_closed()
+        if is_closed:
             msg = "Can't connect to db"
             raise tornado.web.HTTPError(status_code=500, log_message=msg)
 
         self.finish("OK")
-
-    def db_health(self):
-        is_closed = db_proxy.is_closed()
-        if is_closed:
-            return False
-        return True
 
 
 class APIHandler(BaseHandler):

--- a/handlers/base.py
+++ b/handlers/base.py
@@ -12,7 +12,8 @@ from tornado.httputil import HTTPHeaders
 
 from lib.metrics import write_metric, Unit
 from lib.config import config
-from db.mappings.base import db_proxy
+from db.mappings.model import Model
+
 
 DEFAULT_PAGE_SIZE = config.get("DEFAULT_PAGE_SIZE")
 # buffer of latency values for each handler/site combination
@@ -105,6 +106,8 @@ class BaseHandler(tornado.web.RequestHandler):
             LATENCY_BUFFERS[key].push(latency)
 
     def on_finish(self):
+        if self.handler_name == "Health":
+            return
         latency = (time.time() - self.start_time) * 1000
         if not 200 <= self._status_code < 300:
             self.write_error_metric(latency)
@@ -125,9 +128,11 @@ class HealthHandler(BaseHandler):
     """Return 200 OK."""
 
     def get(self):
-        is_closed = db_proxy.is_closed()
-        if is_closed:
+        try:
+            Model.select().limit(1).count()
+        except:
             msg = "Can't connect to db"
+            logging.exception(msg)
             raise tornado.web.HTTPError(status_code=500, log_message=msg)
 
         self.finish("OK")


### PR DESCRIPTION
## description 
adds check for db connection health to our standard `/health` endpoint

this means that when the api becomes unhealhty and is no longer able to connect to the db, aws will redeploy the service for us 